### PR TITLE
client: add ability to disable RTP sender checks

### DIFF
--- a/clientconf.go
+++ b/clientconf.go
@@ -51,6 +51,11 @@ type ClientConf struct {
 	// It defaults to false.
 	RedirectDisable bool
 
+	// disable sender checks to prevent received packets from being dropped if source IP:PORT doesn't
+	// match with RTSP setup (server_port from 'Transport' header)
+	// It defaults to false.
+	SenderCheckDisable bool
+
 	// read buffer count.
 	// If greater than 1, allows to pass buffers to routines different than the one
 	// that is reading frames.

--- a/clientconnudpl.go
+++ b/clientconnudpl.go
@@ -77,10 +77,12 @@ func (l *clientConnUDPListener) run() {
 			return
 		}
 
-		uaddr := addr.(*net.UDPAddr)
+		if !l.c.conf.SenderCheckDisable {
+			uaddr := addr.(*net.UDPAddr)
 
-		if !l.remoteIP.Equal(uaddr.IP) || l.remotePort != uaddr.Port {
-			continue
+			if !l.remoteIP.Equal(uaddr.IP) || l.remotePort != uaddr.Port {
+				continue
+			}
 		}
 
 		now := time.Now()


### PR DESCRIPTION
In some cases that would be useful to disable RTP sender IP:PORT checks.

In my case, I was having issues doing playback from an RTSP server which doesn't support RTCP, and then uses `server_port=0-0` in SETUP's reply `Transport:` header.