### PR TITLE
track: fix parsing fmtp attribute from a VLC generated SDP

### DIFF
--- a/track.go
+++ b/track.go
@@ -94,6 +94,10 @@ func (t *Track) ExtractDataH264() ([]byte, []byte, error) {
 	for _, kv := range strings.Split(tmp[1], ";") {
 		kv = strings.Trim(kv, " ")
 
+		if len(kv) == 0 {
+			continue
+		}
+
 		tmp := strings.SplitN(kv, "=", 2)
 		if len(tmp) != 2 {
 			return nil, nil, fmt.Errorf("unable to parse fmtp (%v)", v)
@@ -197,6 +201,10 @@ func (t *Track) ExtractDataAAC() ([]byte, error) {
 
 	for _, kv := range strings.Split(tmp[1], ";") {
 		kv = strings.Trim(kv, " ")
+
+		if len(kv) == 0 {
+			continue
+		}
 
 		tmp := strings.SplitN(kv, "=", 2)
 		if len(tmp) != 2 {


### PR DESCRIPTION
I'm using `vlc` as a RTSP server:

```bash

vlc -I dummy --verbose=2 --loop $sample_file \
    --network-caching=1500 \
    --sout-all --sout-keep \
    --sout='#gather:rtp{sdp=rtsp://:8554/sample.mkv}'

```

which generates the `fmtp` attribute as follows:

`
fmtp:96 packetization-mode=1;profile-level-id=64001f;sprop-parameter-sets=Z2QAH6zZQFAFuwFsgAAAAwCAAAAeB4wYyw==,aOvjyyLA;
`

By splitting the string with `;`, there will be an empty `kv` at the end of the substrings, which should be skipped.

