### PR TITLE
Added unknown source frame handler

### DIFF
--- a/serverhandler.go
+++ b/serverhandler.go
@@ -164,3 +164,16 @@ type ServerHandlerOnFrameCtx struct {
 type ServerHandlerOnFrame interface {
 	OnFrame(*ServerHandlerOnFrameCtx)
 }
+
+// ServerHandlerOnUnknownClientCtx is the context of an UDP frame coming from an unknown source.
+type ServerHandlerOnUnknownClientCtx struct {
+	StreamType StreamType
+	Payload    []byte
+	Clients    map[clientAddr]*clientData
+	ClientAddr clientAddr
+}
+
+// ServerHandlerOnUnknownClient can be implemented by a ServerHandler.
+type ServerHandlerOnUnknownClient interface {
+	OnUnknownClient(*ServerHandlerOnUnknownClientCtx) error
+}

--- a/serverudpl.go
+++ b/serverudpl.go
@@ -128,10 +128,12 @@ func (u *serverUDPListener) run() {
 						})
 						//Check if clientData exists in possibly modified clients list
 						clientData, ok = u.clients[clientAddr]
-						if !ok {
+						if err != nil {
 							return
 						}
-					}
+					} else {
+            return
+          }
 				}
 
 				if clientData.isPublishing {

--- a/serverudpl.go
+++ b/serverudpl.go
@@ -128,7 +128,7 @@ func (u *serverUDPListener) run() {
 						})
 						//Check if clientData exists in possibly modified clients list
 						clientData, ok = u.clients[clientAddr]
-						if err != nil {
+						if  err != nil || !ok {
 							return
 						}
 					} else {


### PR DESCRIPTION
I'm using gortsplib in a scenario where the server is running inside a docker container. After RTSP negotiation UDP frames are coming from random ports so they are dropped in serverUDPListener run().   I have no control over the docker service so I can't turn off the userland-proxy option or use host networking in docker. I've managed to create a simple UDP matching mechanism based on NAT hole punching on the client-side and expecting new connections on the server side. Parsing RTP/RTCP frames I'm able to predict from which client/publisher the frame is coming from and modify SettupedTrack udp ports. 
The problem is that currently, I need to modify serverudpl.go to inject this mechanism. If the library would have a built-in handler for frames coming from an unknown source it would be possible to make it from the connection handling layer. 