### PR TITLE
Decode unconventionally sorted transport header

### DIFF
--- a/pkg/headers/keyval.go
+++ b/pkg/headers/keyval.go
@@ -4,19 +4,16 @@ import (
 	"fmt"
 )
 
-func readKey(origstr string, str string, separator byte) (string, string, error) {
+func readKey(origstr string, str string, separator byte) (string, string) {
 	i := 0
 	for {
-		if i >= len(str) || str[i] == separator {
-			return "", "", fmt.Errorf("unable to read key (%v)", origstr)
-		}
-		if str[i] == '=' {
+		if i >= len(str) || str[i] == '=' || str[i] == separator {
 			break
 		}
 
 		i++
 	}
-	return str[:i], str[i+1:], nil
+	return str[:i], str[i:]
 }
 
 func readValue(origstr string, str string, separator byte) (string, string, error) {
@@ -50,19 +47,23 @@ func keyValParse(str string, separator byte) (map[string]string, error) {
 
 	for len(str) > 0 {
 		var k string
-		var err error
-		k, str, err = readKey(origstr, str, separator)
-		if err != nil {
-			return nil, err
-		}
+		k, str = readKey(origstr, str, separator)
 
-		var v string
-		v, str, err = readValue(origstr, str, separator)
-		if err != nil {
-			return nil, err
-		}
+		if len(k) > 0 {
+			if len(str) > 0 && str[0] == '=' {
+				var v string
+				var err error
+				v, str, err = readValue(origstr, str[1:], separator)
+				if err != nil {
+					return nil, err
+				}
 
-		ret[k] = v
+				ret[k] = v
+			} else {
+				ret[k] = ""
+
+			}
+		}
 
 		// skip separator
 		if len(str) > 0 && str[0] == separator {

--- a/pkg/headers/keyval_test.go
+++ b/pkg/headers/keyval_test.go
@@ -52,6 +52,30 @@ func TestKeyValParse(t *testing.T) {
 				"key2": "v2",
 			},
 		},
+		{
+			"no val key1",
+			`key1, key2="v2"`,
+			map[string]string{
+				"key1": "",
+				"key2": "v2",
+			},
+		},
+		{
+			"no val key2",
+			`key1="v=1", key2`,
+			map[string]string{
+				"key1": "v=1",
+				"key2": "",
+			},
+		},
+		{
+			"no val key1 nor key2",
+			`key1, key2`,
+			map[string]string{
+				"key1": "",
+				"key2": "",
+			},
+		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {
 			kvs, err := keyValParse(ca.s, ',')
@@ -71,16 +95,6 @@ func TestKeyValParseError(t *testing.T) {
 			"apexes not closed",
 			`key1="v,1`,
 			"apexes not closed (key1=\"v,1)",
-		},
-		{
-			"no key 1",
-			`key=val,missing`,
-			"unable to read key (key=val,missing)",
-		},
-		{
-			"no key 2",
-			`missing,key=val`,
-			"unable to read key (missing,key=val)",
 		},
 	} {
 		t.Run(ca.name, func(t *testing.T) {

--- a/pkg/headers/rtpinfo_test.go
+++ b/pkg/headers/rtpinfo_test.go
@@ -204,11 +204,6 @@ func TestRTPInfoReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
-			"no key",
-			base.HeaderValue{`nokey;key=val`},
-			"unable to read key (nokey;key=val)",
-		},
-		{
 			"invalid sequence",
 			base.HeaderValue{`url=rtsp://127.0.0.1/test.mkv/track1;seq=aa;rtptime=717574556`},
 			"strconv.ParseUint: parsing \"aa\": invalid syntax",

--- a/pkg/headers/rtpinfo_test.go
+++ b/pkg/headers/rtpinfo_test.go
@@ -204,6 +204,11 @@ func TestRTPInfoReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
+			"invalid key-value",
+			base.HeaderValue{"test=\"a"},
+			"apexes not closed (test=\"a)",
+		},
+		{
 			"invalid sequence",
 			base.HeaderValue{`url=rtsp://127.0.0.1/test.mkv/track1;seq=aa;rtptime=717574556`},
 			"strconv.ParseUint: parsing \"aa\": invalid syntax",

--- a/pkg/headers/session_test.go
+++ b/pkg/headers/session_test.go
@@ -85,6 +85,11 @@ func TestSessionReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
+			"invalid key-value",
+			base.HeaderValue{"A3eqwsafq3rFASqew;test=\"a"},
+			"apexes not closed (test=\"a)",
+		},
+		{
 			"invalid timeout",
 			base.HeaderValue{`A3eqwsafq3rFASqew;timeout=aaa`},
 			"strconv.ParseUint: parsing \"aaa\": invalid syntax",

--- a/pkg/headers/session_test.go
+++ b/pkg/headers/session_test.go
@@ -85,11 +85,6 @@ func TestSessionReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
-			"no keys",
-			base.HeaderValue{`A3eqwsafq3rFASqew;aaaa`},
-			"unable to read key (aaaa)",
-		},
-		{
 			"invalid timeout",
 			base.HeaderValue{`A3eqwsafq3rFASqew;timeout=aaa`},
 			"strconv.ParseUint: parsing \"aaa\": invalid syntax",

--- a/pkg/headers/transport_test.go
+++ b/pkg/headers/transport_test.go
@@ -171,9 +171,9 @@ func TestTransportReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
-			"invalid protocol",
+			"protocol not found",
 			base.HeaderValue{`invalid;unicast;client_port=14186-14187`},
-			"invalid protocol (invalid;unicast;client_port=14186-14187)",
+			"protocol not found (invalid;unicast;client_port=14186-14187)",
 		},
 		{
 			"invalid interleaved port",

--- a/pkg/headers/transport_test.go
+++ b/pkg/headers/transport_test.go
@@ -115,6 +115,23 @@ var casesTransport = []struct {
 			ServerPorts: &[2]int{5000, 5001},
 		},
 	},
+	{
+		"unsorted udp unicast play request headers",
+		base.HeaderValue{`client_port=3456-3457;RTP/AVP;mode="PLAY";unicast`},
+		base.HeaderValue{`RTP/AVP;unicast;client_port=3456-3457;mode=play`},
+		Transport{
+			Protocol: base.StreamProtocolUDP,
+			Delivery: func() *base.StreamDelivery {
+				v := base.StreamDeliveryUnicast
+				return &v
+			}(),
+			ClientPorts: &[2]int{3456, 3457},
+			Mode: func() *TransportMode {
+				v := TransportModePlay
+				return &v
+			}(),
+		},
+	},
 }
 
 func TestTransportRead(t *testing.T) {
@@ -154,14 +171,9 @@ func TestTransportReadError(t *testing.T) {
 			"value provided multiple times ([a b])",
 		},
 		{
-			"missing delivery",
-			base.HeaderValue{`RTP/AVP`},
-			"unable to read key (;)",
-		},
-		{
 			"invalid protocol",
 			base.HeaderValue{`invalid;unicast;client_port=14186-14187`},
-			"invalid protocol (unicast;client_port=14186-14187)",
+			"invalid protocol (invalid;unicast;client_port=14186-14187)",
 		},
 		{
 			"invalid interleaved port",


### PR DESCRIPTION
Resolves issue #34 by ...

1. Allowing transport header field keys without values (ex: `key1;key2=value;key3`).
2. Parsing all header fields (specifically stream protocol and stream delivery options) without expecting them in a specific order.

New tests for value-less-keys have also been added and old error-tests checking for errors on value-less-keys have been removed.