### PR TITLE
client: allow RTP packets to come from a different source that RTSP host

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,6 +81,13 @@ type Client struct {
 	// This must be touched only when the server reports errors about buffer sizes.
 	// It defaults to 2048.
 	ReadBufferSize int
+	// Allow RTP packets to come from a different host than the address used for RTSP signaling.
+	// This can be useful if a client wants to listen to a stream from a server which is listening on
+	// different IPs/subnets, as the source of the RTP packets might be determined by the server's
+	// routing table / network stack.
+	// this can be a security issue.
+	// It defaults to false.
+	AnyHostEnable bool
 
 	//
 	// callbacks

--- a/clientconnudpl.go
+++ b/clientconnudpl.go
@@ -160,7 +160,7 @@ func (l *clientConnUDPListener) run() {
 
 			uaddr := addr.(*net.UDPAddr)
 
-			if !l.remoteReadIP.Equal(uaddr.IP) || (!isAnyPort(l.remotePort) && l.remotePort != uaddr.Port) {
+			if (!l.cc.c.AnyHostEnable && !l.remoteReadIP.Equal(uaddr.IP)) || (!isAnyPort(l.remotePort) && l.remotePort != uaddr.Port) {
 				continue
 			}
 
@@ -179,7 +179,7 @@ func (l *clientConnUDPListener) run() {
 
 			uaddr := addr.(*net.UDPAddr)
 
-			if !l.remoteReadIP.Equal(uaddr.IP) || (!isAnyPort(l.remotePort) && l.remotePort != uaddr.Port) {
+			if (!l.cc.c.AnyHostEnable && !l.remoteReadIP.Equal(uaddr.IP)) || (!isAnyPort(l.remotePort) && l.remotePort != uaddr.Port) {
 				continue
 			}
 


### PR DESCRIPTION
This is related to a discussion which happened in that PR few month ago : https://github.com/aler9/gortsplib/pull/21#issuecomment-763992570