### PR TITLE
serverconn: allow passing of raw base.Response.Body from Describe callbacks

### DIFF
--- a/serverconn.go
+++ b/serverconn.go
@@ -357,7 +357,10 @@ func (sc *ServerConn) handleRequest(req *base.Request) (*base.Response, error) {
 
 				res.Header["Content-Base"] = base.HeaderValue{req.URL.String() + "/"}
 				res.Header["Content-Type"] = base.HeaderValue{"application/sdp"}
-				res.Body = stream.Tracks().Write()
+
+				if stream != nil {
+					res.Body = stream.Tracks().Write()
+				}
 			}
 
 			return res, err


### PR DESCRIPTION
When a server handler implements `OnDescribe()` it may return a
`base.Reponse` that carries a body, along with a `nil` stream.

`handleRequest()` should support that, and not override `res.Body`, and,
more importantly, not dereference the returned `nil` pointer.