### PR TITLE
handle hex session id

### DIFF
--- a/pkg/sdp/sdp.go
+++ b/pkg/sdp/sdp.go
@@ -97,7 +97,13 @@ func (s *SessionDescription) unmarshalOrigin(value string) error {
 		return fmt.Errorf("%w `o=%v`", errSDPInvalidSyntax, fields)
 	}
 
-	sessionID, err := strconv.ParseUint(fields[1], 10, 64)
+	var sessionID uint64
+	var err error
+	if strings.HasPrefix(fields[1], "0x") {
+		sessionID, err = strconv.ParseUint(fields[1][len("0x"):], 16, 64)
+	} else {
+		sessionID, err = strconv.ParseUint(fields[1], 10, 64)
+	}
 	if err != nil {
 		return fmt.Errorf("%w `%v`", errSDPInvalidNumericValue, fields[1])
 	}

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -1180,6 +1180,37 @@ var cases = []struct {
 			},
 		},
 	},
+	{
+		"hex session id",
+		[]byte("v=0\r\n" +
+			"o=jdoe 0xAC4EC96E 2890842807 IN IP4 10.47.16.5\r\n" +
+			"s=SDP Seminar\r\n" +
+			"i=A Seminar on the session description protocol\r\n" +
+			"t=3034423619 3042462419\r\n"),
+		[]byte("v=0\r\n" +
+			"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +
+			"s=SDP Seminar\r\n" +
+			"i=A Seminar on the session description protocol\r\n" +
+			"t=3034423619 3042462419\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "jdoe",
+				SessionID:      2890844526,
+				SessionVersion: 2890842807,
+				NetworkType:    "IN",
+				AddressType:    "IP4",
+				UnicastAddress: "10.47.16.5",
+			},
+			SessionName: "SDP Seminar",
+			SessionInformation: func() *psdp.Information {
+				v := psdp.Information("A Seminar on the session description protocol")
+				return &v
+			}(),
+			TimeDescriptions: []psdp.TimeDescription{
+				{psdp.Timing{3034423619, 3042462419}, nil},
+			},
+		},
+	},
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
I found that my rtsp source had hexadecimal session ID when using rtsp-simple-server.

The error is shown as following:
**ERR: sdp: invalid numeric value `0xfbc380` (o=- 0xfbc380 1 IN IP4 192.168.2.9)**

I added this code to your work and it worked just fine.  I hope this could be merged into your work. Thanks!
