### PR TITLE
Default interleaved ids if not specified

### DIFF
--- a/pkg/liberrors/server.go
+++ b/pkg/liberrors/server.go
@@ -159,14 +159,6 @@ func (e ErrServerTransportHeaderNoClientPorts) Error() string {
 	return "transport header does not contain client ports"
 }
 
-// ErrServerTransportHeaderNoInterleavedIDs is an error that can be returned by a server.
-type ErrServerTransportHeaderNoInterleavedIDs struct{}
-
-// Error implements the error interface.
-func (e ErrServerTransportHeaderNoInterleavedIDs) Error() string {
-	return "transport header does not contain interleaved IDs"
-}
-
 // ErrServerTransportHeaderInvalidInterleavedIDs is an error that can be returned by a server.
 type ErrServerTransportHeaderInvalidInterleavedIDs struct{}
 

--- a/serversession.go
+++ b/serversession.go
@@ -605,9 +605,8 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 			}
 
 			if inTH.InterleavedIDs == nil {
-				return &base.Response{
-					StatusCode: base.StatusBadRequest,
-				}, liberrors.ErrServerTransportHeaderNoInterleavedIDs{}
+				// Defaulting to inteleaved id 0,1
+				inTH.InterleavedIDs = &[2]int{0,1}
 			}
 
 			if (inTH.InterleavedIDs[0]+1) != inTH.InterleavedIDs[1] ||


### PR DESCRIPTION
See Issue #63 
Defaulting to 0-1 as interleaved ids if not provided in the request.