### PR TITLE
fix ExtractConfigH264() when extradata is present

### DIFF
--- a/track_h264.go
+++ b/track_h264.go
@@ -96,8 +96,8 @@ func (t *Track) ExtractConfigH264() (*TrackConfigH264, error) {
 		}
 
 		if tmp[0] == "sprop-parameter-sets" {
-			tmp := strings.SplitN(tmp[1], ",", 2)
-			if len(tmp) != 2 {
+			tmp := strings.SplitN(tmp[1], ",", 3)
+			if len(tmp) < 2 {
 				return nil, fmt.Errorf("invalid sprop-parameter-sets (%v)", v)
 			}
 


### PR DESCRIPTION
The `sprop-parameter-sets` parameter in a SDP description of a H.264 stream could contain more that two fields. These fields could be considered extradata. Some tools like ffmpeg incorporate them if they are available. You can read about specs of this parameter at https://www.ietf.org/archive/id/draft-lennox-avt-h264-source-fmtp-00.html#anchor3 .

This is an example of a working description:
`a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z01AKJJSgPAIj7wEQAAAAwBAAAAMo8WLZYA=,aP48gAA=; profile-level-id=4D4028`

And this is another example that fails without this PR:
`a=fmtp:96 packetization-mode=1; sprop-parameter-sets=Z2QAKawTMUB4BEfeA+oCAgPgAAADACAAAAZSgA==,aPqPLA==,aF6jzAMA; profile-level-id=640029`

So assuming the optional presence of more than two fields in the `sprop-parameter-sets` parameter with PR solves the bug.