### PR TITLE
track: expose MediaDescription() and Set/GetControl()

### DIFF
--- a/server_publish_test.go
+++ b/server_publish_test.go
@@ -42,7 +42,7 @@ func invalidURLAnnounceReq(t *testing.T, control string) base.Request {
 					{Timing: psdp.Timing{0, 0}}, //nolint:govet
 				},
 				MediaDescriptions: []*psdp.MediaDescription{
-					track.mediaDescription(),
+					track.MediaDescription(),
 				},
 			}
 
@@ -274,7 +274,7 @@ func TestServerPublishSetupPath(t *testing.T) {
 					{Timing: psdp.Timing{0, 0}}, //nolint:govet
 				},
 				MediaDescriptions: []*psdp.MediaDescription{
-					track.mediaDescription(),
+					track.MediaDescription(),
 				},
 			}
 

--- a/server_publish_test.go
+++ b/server_publish_test.go
@@ -28,7 +28,7 @@ func invalidURLAnnounceReq(t *testing.T, control string) base.Request {
 		Body: func() []byte {
 			track, err := NewTrackH264(96, []byte{0x01, 0x02, 0x03, 0x04}, []byte{0x01, 0x02, 0x03, 0x04}, nil)
 			require.NoError(t, err)
-			track.setControl(control)
+			track.SetControl(control)
 
 			sout := &psdp.SessionDescription{
 				SessionName: psdp.SessionName("Stream"),
@@ -260,7 +260,7 @@ func TestServerPublishSetupPath(t *testing.T) {
 			track, err := NewTrackH264(96, []byte{0x01, 0x02, 0x03, 0x04}, []byte{0x01, 0x02, 0x03, 0x04}, nil)
 			require.NoError(t, err)
 
-			track.setControl(ca.control)
+			track.SetControl(ca.control)
 
 			sout := &psdp.SessionDescription{
 				SessionName: psdp.SessionName("Stream"),

--- a/track.go
+++ b/track.go
@@ -15,8 +15,10 @@ type Track interface {
 	// ClockRate returns the track clock rate.
 	ClockRate() int
 	clone() Track
-	getControl() string
-	setControl(string)
+	// GetControl returns the track control
+	GetControl() string
+	// SetControl returns the track control
+	SetControl(string)
 	url(*base.URL) (*base.URL, error)
 	// MediaDescription returns structured SDP media information
 	MediaDescription() *psdp.MediaDescription
@@ -76,7 +78,7 @@ func trackURL(t Track, contentBase *base.URL) (*base.URL, error) {
 		return nil, fmt.Errorf("no Content-Base header provided")
 	}
 
-	control := t.getControl()
+	control := t.GetControl()
 
 	// no control attribute, use base URL
 	if control == "" {

--- a/track.go
+++ b/track.go
@@ -14,14 +14,14 @@ import (
 type Track interface {
 	// ClockRate returns the track clock rate.
 	ClockRate() int
-	clone() Track
-	// GetControl returns the track control
+	// GetControl returns the track control.
 	GetControl() string
-	// SetControl returns the track control
+	// SetControl sets the track control.
 	SetControl(string)
-	url(*base.URL) (*base.URL, error)
-	// MediaDescription returns structured SDP media information
+	// MediaDescription returns the media description in SDP format.
 	MediaDescription() *psdp.MediaDescription
+	clone() Track
+	url(*base.URL) (*base.URL, error)
 }
 
 func newTrackFromMediaDescription(md *psdp.MediaDescription) (Track, error) {

--- a/track.go
+++ b/track.go
@@ -18,7 +18,8 @@ type Track interface {
 	getControl() string
 	setControl(string)
 	url(*base.URL) (*base.URL, error)
-	mediaDescription() *psdp.MediaDescription
+	// MediaDescription returns structured SDP media information
+	MediaDescription() *psdp.MediaDescription
 }
 
 func newTrackFromMediaDescription(md *psdp.MediaDescription) (Track, error) {

--- a/track_aac.go
+++ b/track_aac.go
@@ -138,11 +138,13 @@ func (t *TrackAAC) clone() Track {
 	}
 }
 
-func (t *TrackAAC) getControl() string {
+// GetControl gets the track control.
+func (t *TrackAAC) GetControl() string {
 	return t.control
 }
 
-func (t *TrackAAC) setControl(c string) {
+// SetControl sets the track control.
+func (t *TrackAAC) SetControl(c string) {
 	t.control = c
 }
 

--- a/track_aac.go
+++ b/track_aac.go
@@ -152,7 +152,7 @@ func (t *TrackAAC) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-// MediaDescription returns the structured media information from the SDP
+// MediaDescription returns the media description in SDP format.
 func (t *TrackAAC) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 

--- a/track_aac.go
+++ b/track_aac.go
@@ -150,7 +150,8 @@ func (t *TrackAAC) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-func (t *TrackAAC) mediaDescription() *psdp.MediaDescription {
+// MediaDescription returns the structured media information from the SDP
+func (t *TrackAAC) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 
 	return &psdp.MediaDescription{

--- a/track_aac_test.go
+++ b/track_aac_test.go
@@ -49,5 +49,5 @@ func TestTrackAACMediaDescription(t *testing.T) {
 				Value: "",
 			},
 		},
-	}, track.mediaDescription())
+	}, track.MediaDescription())
 }

--- a/track_generic.go
+++ b/track_generic.go
@@ -151,7 +151,8 @@ func (t *TrackGeneric) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-func (t *TrackGeneric) mediaDescription() *psdp.MediaDescription {
+// MediaDescription returns the structured media information from the SDP
+func (t *TrackGeneric) MediaDescription() *psdp.MediaDescription {
 	return &psdp.MediaDescription{
 		MediaName: psdp.MediaName{
 			Media:   t.media,

--- a/track_generic.go
+++ b/track_generic.go
@@ -139,11 +139,13 @@ func (t *TrackGeneric) clone() Track {
 	}
 }
 
-func (t *TrackGeneric) getControl() string {
+// GetControl returns the track control.
+func (t *TrackGeneric) GetControl() string {
 	return t.control
 }
 
-func (t *TrackGeneric) setControl(c string) {
+// SetControl set the track control.
+func (t *TrackGeneric) SetControl(c string) {
 	t.control = c
 }
 

--- a/track_generic.go
+++ b/track_generic.go
@@ -153,7 +153,7 @@ func (t *TrackGeneric) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-// MediaDescription returns the structured media information from the SDP
+// MediaDescription returns the media description in SDP format.
 func (t *TrackGeneric) MediaDescription() *psdp.MediaDescription {
 	return &psdp.MediaDescription{
 		MediaName: psdp.MediaName{

--- a/track_h264.go
+++ b/track_h264.go
@@ -145,7 +145,7 @@ func (t *TrackH264) SetPPS(v []byte) {
 	t.pps = v
 }
 
-// MediaDescription returns the structured SDP media information
+// MediaDescription returns the media description in SDP format.
 func (t *TrackH264) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 

--- a/track_h264.go
+++ b/track_h264.go
@@ -143,7 +143,8 @@ func (t *TrackH264) SetPPS(v []byte) {
 	t.pps = v
 }
 
-func (t *TrackH264) mediaDescription() *psdp.MediaDescription {
+// MediaDescription returns the structured SDP media information
+func (t *TrackH264) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 
 	fmtp := typ + " packetization-mode=1"

--- a/track_h264.go
+++ b/track_h264.go
@@ -111,11 +111,13 @@ func (t *TrackH264) clone() Track {
 	}
 }
 
-func (t *TrackH264) getControl() string {
+// GetControl gets the track control.
+func (t *TrackH264) GetControl() string {
 	return t.control
 }
 
-func (t *TrackH264) setControl(c string) {
+// SetControl sets the track control.
+func (t *TrackH264) SetControl(c string) {
 	t.control = c
 }
 

--- a/track_h264_test.go
+++ b/track_h264_test.go
@@ -218,5 +218,5 @@ func TestTrackH264MediaDescription(t *testing.T) {
 				Value: "",
 			},
 		},
-	}, track.mediaDescription())
+	}, track.MediaDescription())
 }

--- a/track_opus.go
+++ b/track_opus.go
@@ -83,7 +83,7 @@ func (t *TrackOpus) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-// MediaDescription returns the structured media information from the SDP
+// MediaDescription returns the media description in SDP format.
 func (t *TrackOpus) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 

--- a/track_opus.go
+++ b/track_opus.go
@@ -81,7 +81,8 @@ func (t *TrackOpus) url(contentBase *base.URL) (*base.URL, error) {
 	return trackURL(t, contentBase)
 }
 
-func (t *TrackOpus) mediaDescription() *psdp.MediaDescription {
+// MediaDescription returns the structured media information from the SDP
+func (t *TrackOpus) MediaDescription() *psdp.MediaDescription {
 	typ := strconv.FormatInt(int64(t.payloadType), 10)
 
 	return &psdp.MediaDescription{

--- a/track_opus.go
+++ b/track_opus.go
@@ -69,11 +69,13 @@ func (t *TrackOpus) clone() Track {
 	}
 }
 
-func (t *TrackOpus) getControl() string {
+// GetControl returns the track control.
+func (t *TrackOpus) GetControl() string {
 	return t.control
 }
 
-func (t *TrackOpus) setControl(c string) {
+// SetControl sets the track control.
+func (t *TrackOpus) SetControl(c string) {
 	t.control = c
 }
 

--- a/track_opus_test.go
+++ b/track_opus_test.go
@@ -47,5 +47,5 @@ func TestTrackOpusMediaDescription(t *testing.T) {
 				Value: "",
 			},
 		},
-	}, track.mediaDescription())
+	}, track.MediaDescription())
 }

--- a/tracks.go
+++ b/tracks.go
@@ -75,7 +75,7 @@ func (ts Tracks) Write(multicast bool) []byte {
 	}
 
 	for _, track := range ts {
-		sout.MediaDescriptions = append(sout.MediaDescriptions, track.mediaDescription())
+		sout.MediaDescriptions = append(sout.MediaDescriptions, track.MediaDescription())
 	}
 
 	byts, _ := sout.Marshal()

--- a/tracks.go
+++ b/tracks.go
@@ -44,7 +44,7 @@ func (ts Tracks) clone() Tracks {
 
 func (ts Tracks) setControls() {
 	for i, t := range ts {
-		t.setControl("trackID=" + strconv.FormatInt(int64(i), 10))
+		t.SetControl("trackID=" + strconv.FormatInt(int64(i), 10))
 	}
 }
 


### PR DESCRIPTION
Prior to commit 6d5bf0c1bb90f8e6b3c80acc32ac37f958075303, gortsplib clients could access the media description through the `Media` field, which could be used to access SDP fields and media type (audio vs. video). When this was replaced with the private `mediaDescription`, that ability was lost. This PR exposes `MediaDescription()` to restore access to these fields.