### PR TITLE
Fix handling of trailing space in origin-field

### DIFF
--- a/pkg/sdp/sdp.go
+++ b/pkg/sdp/sdp.go
@@ -66,31 +66,17 @@ func (s *SessionDescription) unmarshalOrigin(value string) error {
 		value = "- 0 " + value[3:]
 	}
 
-	// special case for sone onvif2 cameras
-	if value[len(value)-1] == ' ' {
-		value += "127.0.0.1"
-	}
-
 	// find spaces from end to beginning, to support multiple spaces
 	// in the first field
 	fields := func() []string {
-		var ret []string
-		for len(value) > 0 {
-			i := len(value) - 1
-			for {
-				if i < 0 || len(ret) == 5 {
-					ret = append([]string{value}, ret...)
-					return ret
-				}
-				if value[i] == ' ' {
-					ret = append([]string{value[i+1:]}, ret...)
-					value = value[:i]
-					break
-				}
-				i--
-			}
+		values := strings.Split(strings.TrimSpace(value), " ")
+
+		// special case for some onvif2 cameras
+		if strings.Compare(values[len(values)-1], "IP4") == 0 {
+			values = append(values, "127.0.0.1")
 		}
-		return ret
+
+		return append([]string{strings.Join(values[0:len(values)-5], " ")}, values[len(values)-5:]...)
 	}()
 
 	if len(fields) != 6 {

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -1383,6 +1383,86 @@ var cases = []struct {
 		},
 	},
 	{
+		"FLIR IOI TRK-101 with trailing space in origin field",
+		[]byte("v=0\r\n" +
+			"o=- 1 1 IN IP4 127.0.0.1 \r\n" +
+			"s=RTP session\r\n" +
+			"e=NONE\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n" +
+			"a=rtpmap:96 MP4V-ES/1000\r\n" +
+			"a=fmtp:96 profile-level-id=245; config=000001B0F5000001B509000001000000012000845D4C28582120A31F\r\n" +
+			"a=framerate:25\r\n" +
+			"a=x-dimensions:352,288\r\n" +
+			"a=x-algoTarget:P\r\n" +
+			"a=control:video\r\n"),
+		[]byte("v=0\r\n" +
+			"o=- 1 1 IN IP4 127.0.0.1\r\n" +
+			"s=RTP session\r\n" +
+			"e=NONE\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n" +
+			"a=rtpmap:96 MP4V-ES/1000\r\n" +
+			"a=fmtp:96 profile-level-id=245; config=000001B0F5000001B509000001000000012000845D4C28582120A31F\r\n" +
+			"a=framerate:25\r\n" +
+			"a=x-dimensions:352,288\r\n" +
+			"a=x-algoTarget:P\r\n" +
+			"a=control:video\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "-",
+				SessionID:      1,
+				SessionVersion: 1,
+				NetworkType:    "IN",
+				AddressType:    "IP4",
+				UnicastAddress: "127.0.0.1",
+			},
+			SessionName: "RTP session",
+			TimeDescriptions: []psdp.TimeDescription{
+				{psdp.Timing{0, 0}, nil},
+			},
+			EmailAddress: func() *psdp.EmailAddress {
+				e := psdp.EmailAddress("NONE")
+				return &e
+			}(),
+			MediaDescriptions: []*psdp.MediaDescription{
+				{
+					MediaName: psdp.MediaName{
+						Media:   "video",
+						Protos:  []string{"RTP", "AVP"},
+						Formats: []string{"96"},
+					},
+					Attributes: []psdp.Attribute{
+						{
+							Key:   "rtpmap",
+							Value: "96 MP4V-ES/1000",
+						},
+						{
+							Key:   "fmtp",
+							Value: "96 profile-level-id=245; config=000001B0F5000001B509000001000000012000845D4C28582120A31F",
+						},
+						{
+							Key:   "framerate",
+							Value: "25",
+						},
+						{
+							Key:   "x-dimensions",
+							Value: "352,288",
+						},
+						{
+							Key:   "x-algoTarget",
+							Value: "P",
+						},
+						{
+							Key:   "control",
+							Value: "video",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
 		"hex session id for 0XAC4EC96E",
 		[]byte("v=0\r\n" +
 			"o=jdoe 0XAC4EC96E 2890842807 IN IP4 10.47.16.5\r\n" +


### PR DESCRIPTION
We use the IOI trk-101. This device returns an origin-field with a
trailing space. This triggered the special case for some onvif2 cameras.
This resulted in a double unicast-address, causing a shift in the
fields. Eventually resulting in an exception when nettype was
interpret as sess-version.

This commit fixes this issue and adds a testcase that includes a
trailing whitespace.