### PR TITLE
client: allow UserAgent to be set

### DIFF
--- a/client.go
+++ b/client.go
@@ -184,7 +184,7 @@ type Client struct {
 	ReadBufferCount int
 	// write buffer count.
 	// It allows to queue packets before sending them.
-	// It defaults to 8.
+	// It defaults to 256.
 	WriteBufferCount int
 	// user agent header
 	// It defaults to "gortsplib"

--- a/client.go
+++ b/client.go
@@ -186,6 +186,9 @@ type Client struct {
 	// It allows to queue packets before sending them.
 	// It defaults to 8.
 	WriteBufferCount int
+	// user agent header
+	// It defaults to "gortsplib"
+	UserAgent string
 
 	//
 	// system functions
@@ -284,6 +287,9 @@ func (c *Client) Start(scheme string, host string) error {
 	}
 	if c.WriteBufferCount == 0 {
 		c.WriteBufferCount = 256
+	}
+	if c.UserAgent == "" {
+		c.UserAgent = "gortsplib"
 	}
 
 	// system functions
@@ -1037,7 +1043,7 @@ func (c *Client) do(req *base.Request, skipResponse bool, allowFrames bool) (*ba
 	c.cseq++
 	req.Header["CSeq"] = base.HeaderValue{strconv.FormatInt(int64(c.cseq), 10)}
 
-	req.Header["User-Agent"] = base.HeaderValue{"gortsplib"}
+	req.Header["User-Agent"] = base.HeaderValue{c.UserAgent}
 
 	if c.sender != nil {
 		c.sender.AddAuthorization(req)


### PR DESCRIPTION
It's helpful for debugging to be able to override the hardcoded `gortsplib` User-Agent header, as we can have multiple gortsplib-based clients. I'd also be open to making this a config option or a parameter to the Client, but this was the lowest impact change. 

It also has the advantage that this parameter can be changed by e.g., docker image without rebuilding.
