### PR TITLE
Persist credentials on source redirections

### DIFF
--- a/client.go
+++ b/client.go
@@ -1218,10 +1218,6 @@ func (c *Client) doDescribe(u *base.URL) (Tracks, *base.URL, *base.Response, err
 
 			if u.User != nil {
 				ru.User = u.User
-				ru, err = base.ParseURL(ru.String())
-				if err != nil {
-					return nil, nil, nil, err
-				}
 			}
 
 			c.scheme = ru.Scheme

--- a/client.go
+++ b/client.go
@@ -163,9 +163,6 @@ type Client struct {
 	// disable being redirected to other servers, that can happen during Describe().
 	// It defaults to false.
 	RedirectDisable bool
-	// use the credentials (user/pass) of the source RTSP url to authenticate with the redirect url.
-	// It defaults to false.
-	PersistCredentialsOnRedirect bool
 	// enable communication with servers which don't provide server ports or use
 	// different server ports than the ones announced.
 	// This can be a security issue.
@@ -1219,7 +1216,7 @@ func (c *Client) doDescribe(u *base.URL) (Tracks, *base.URL, *base.Response, err
 				return nil, nil, nil, err
 			}
 
-			if c.PersistCredentialsOnRedirect && u.User != nil {
+			if u.User != nil {
 				ru.User = u.User
 				ru, err = base.ParseURL(ru.String())
 				if err != nil {

--- a/client_read_test.go
+++ b/client_read_test.go
@@ -1573,16 +1573,15 @@ func TestClientReadDifferentInterleavedIDs(t *testing.T) {
 }
 
 func TestClientReadRedirect(t *testing.T) {
-	for _, persistCredentialsOnRedirect := range []bool{false, true} {
-		runName := "NoPersistCredentialsOnRedirect"
-		if persistCredentialsOnRedirect {
-			runName = "PersistCredentialsOnRedirect"
+	for _, withCredentials := range []bool{false, true} {
+		runName := "WithoutCredentials"
+		if withCredentials {
+			runName = "WithCredentials"
 		}
 		t.Run(runName, func(t *testing.T) {
 			packetRecv := make(chan struct{})
 
 			c := Client{
-				PersistCredentialsOnRedirect: persistCredentialsOnRedirect,
 				OnPacketRTP: func(ctx *ClientOnPacketRTPCtx) {
 					close(packetRecv)
 				},
@@ -1660,7 +1659,7 @@ func TestClientReadRedirect(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, base.Describe, req.Method)
 
-				if persistCredentialsOnRedirect {
+				if withCredentials {
 					if _, exists := req.Header["Authorization"]; !exists {
 						authRealm := "example@localhost"
 						authNonce := "exampleNonce"
@@ -1758,7 +1757,7 @@ func TestClientReadRedirect(t *testing.T) {
 			}()
 
 			ru := "rtsp://localhost:8554/path1"
-			if persistCredentialsOnRedirect {
+			if withCredentials {
 				ru = "rtsp://testusr:testpwd@localhost:8554/path1"
 			}
 			err = c.StartReading(ru)

--- a/client_read_test.go
+++ b/client_read_test.go
@@ -1573,154 +1573,201 @@ func TestClientReadDifferentInterleavedIDs(t *testing.T) {
 }
 
 func TestClientReadRedirect(t *testing.T) {
-	l, err := net.Listen("tcp", "localhost:8554")
-	require.NoError(t, err)
-	defer l.Close()
+	for _, persistCredentialsOnRedirect := range []bool{false, true} {
+		runName := "NoPersistCredentialsOnRedirect"
+		if persistCredentialsOnRedirect {
+			runName = "PersistCredentialsOnRedirect"
+		}
+		t.Run(runName, func(t *testing.T) {
+			packetRecv := make(chan struct{})
 
-	serverDone := make(chan struct{})
-	defer func() { <-serverDone }()
-	go func() {
-		defer close(serverDone)
+			c := Client{
+				PersistCredentialsOnRedirect: persistCredentialsOnRedirect,
+				OnPacketRTP: func(ctx *ClientOnPacketRTPCtx) {
+					close(packetRecv)
+				},
+			}
 
-		conn, err := l.Accept()
-		require.NoError(t, err)
-		br := bufio.NewReader(conn)
+			l, err := net.Listen("tcp", "localhost:8554")
+			require.NoError(t, err)
+			defer l.Close()
 
-		req, err := readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Options, req.Method)
+			serverDone := make(chan struct{})
+			defer func() { <-serverDone }()
+			go func() {
+				defer close(serverDone)
 
-		byts, _ := base.Response{
-			StatusCode: base.StatusOK,
-			Header: base.Header{
-				"Public": base.HeaderValue{strings.Join([]string{
-					string(base.Describe),
-					string(base.Setup),
-					string(base.Play),
-				}, ", ")},
-			},
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				conn, err := l.Accept()
+				require.NoError(t, err)
+				br := bufio.NewReader(conn)
 
-		req, err = readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Describe, req.Method)
+				req, err := readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Options, req.Method)
 
-		byts, _ = base.Response{
-			StatusCode: base.StatusMovedPermanently,
-			Header: base.Header{
-				"Location": base.HeaderValue{"rtsp://localhost:8554/test"},
-			},
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				byts, _ := base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Public": base.HeaderValue{strings.Join([]string{
+							string(base.Describe),
+							string(base.Setup),
+							string(base.Play),
+						}, ", ")},
+					},
+				}.Write()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
 
-		conn.Close()
+				req, err = readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Describe, req.Method)
 
-		conn, err = l.Accept()
-		require.NoError(t, err)
-		defer conn.Close()
-		br = bufio.NewReader(conn)
+				byts, _ = base.Response{
+					StatusCode: base.StatusMovedPermanently,
+					Header: base.Header{
+						"Location": base.HeaderValue{"rtsp://localhost:8554/test"},
+					},
+				}.Write()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
 
-		req, err = readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Options, req.Method)
+				conn.Close()
 
-		byts, _ = base.Response{
-			StatusCode: base.StatusOK,
-			Header: base.Header{
-				"Public": base.HeaderValue{strings.Join([]string{
-					string(base.Describe),
-					string(base.Setup),
-					string(base.Play),
-				}, ", ")},
-			},
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				conn, err = l.Accept()
+				require.NoError(t, err)
+				defer conn.Close()
+				br = bufio.NewReader(conn)
 
-		req, err = readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Describe, req.Method)
+				req, err = readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Options, req.Method)
 
-		track, err := NewTrackH264(96, []byte{0x01, 0x02, 0x03, 0x04}, []byte{0x01, 0x02, 0x03, 0x04}, nil)
-		require.NoError(t, err)
+				byts, _ = base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Public": base.HeaderValue{strings.Join([]string{
+							string(base.Describe),
+							string(base.Setup),
+							string(base.Play),
+						}, ", ")},
+					},
+				}.Write()
 
-		tracks := Tracks{track}
-		tracks.setControls()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
 
-		byts, _ = base.Response{
-			StatusCode: base.StatusOK,
-			Header: base.Header{
-				"Content-Type": base.HeaderValue{"application/sdp"},
-				"Content-Base": base.HeaderValue{"rtsp://localhost:8554/teststream/"},
-			},
-			Body: tracks.Write(false),
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				req, err = readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Describe, req.Method)
 
-		req, err = readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Setup, req.Method)
+				if persistCredentialsOnRedirect {
+					if _, exists := req.Header["Authorization"]; !exists {
+						authRealm := "example@localhost"
+						authNonce := "exampleNonce"
+						authOpaque := "exampleOpaque"
+						authStale := "FALSE"
+						authAlg := "MD5"
+						byts, _ = base.Response{
+							Header: base.Header{
+								"WWW-Authenticate": headers.Authenticate{
+									Method:    headers.AuthDigest,
+									Realm:     &authRealm,
+									Nonce:     &authNonce,
+									Opaque:    &authOpaque,
+									Stale:     &authStale,
+									Algorithm: &authAlg,
+								}.Write(),
+							},
+							StatusCode: base.StatusUnauthorized,
+						}.Write()
+						_, err = conn.Write(byts)
+						require.NoError(t, err)
+					}
+					req, err = readRequest(br)
+					require.NoError(t, err)
+					authHeaderVal, exists := req.Header["Authorization"]
+					require.True(t, exists)
+					var authHeader headers.Authenticate
+					require.NoError(t, authHeader.Read(authHeaderVal))
+					require.Equal(t, *authHeader.Username, "testusr")
+					require.Equal(t, base.Describe, req.Method)
+				}
 
-		var th headers.Transport
-		err = th.Read(req.Header["Transport"])
-		require.NoError(t, err)
+				track, err := NewTrackH264(96, []byte{0x01, 0x02, 0x03, 0x04}, []byte{0x01, 0x02, 0x03, 0x04}, nil)
+				require.NoError(t, err)
 
-		byts, _ = base.Response{
-			StatusCode: base.StatusOK,
-			Header: base.Header{
-				"Transport": headers.Transport{
-					Protocol: headers.TransportProtocolUDP,
-					Delivery: func() *headers.TransportDelivery {
-						v := headers.TransportDeliveryUnicast
-						return &v
-					}(),
-					ClientPorts: th.ClientPorts,
-					ServerPorts: &[2]int{34556, 34557},
-				}.Write(),
-			},
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				tracks := Tracks{track}
+				tracks.setControls()
 
-		req, err = readRequest(br)
-		require.NoError(t, err)
-		require.Equal(t, base.Play, req.Method)
+				byts, _ = base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Content-Type": base.HeaderValue{"application/sdp"},
+						"Content-Base": base.HeaderValue{"rtsp://localhost:8554/teststream/"},
+					},
+					Body: tracks.Write(false),
+				}.Write()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
 
-		byts, _ = base.Response{
-			StatusCode: base.StatusOK,
-		}.Write()
-		_, err = conn.Write(byts)
-		require.NoError(t, err)
+				req, err = readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Setup, req.Method)
 
-		time.Sleep(500 * time.Millisecond)
+				var th headers.Transport
+				err = th.Read(req.Header["Transport"])
+				require.NoError(t, err)
 
-		l1, err := net.ListenPacket("udp", "localhost:34556")
-		require.NoError(t, err)
-		defer l1.Close()
+				byts, _ = base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Transport": headers.Transport{
+							Protocol: headers.TransportProtocolUDP,
+							Delivery: func() *headers.TransportDelivery {
+								v := headers.TransportDeliveryUnicast
+								return &v
+							}(),
+							ClientPorts: th.ClientPorts,
+							ServerPorts: &[2]int{34556, 34557},
+						}.Write(),
+					},
+				}.Write()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
 
-		l1.WriteTo(testRTPPacketMarshaled, &net.UDPAddr{
-			IP:   net.ParseIP("127.0.0.1"),
-			Port: th.ClientPorts[0],
+				req, err = readRequest(br)
+				require.NoError(t, err)
+				require.Equal(t, base.Play, req.Method)
+
+				byts, _ = base.Response{
+					StatusCode: base.StatusOK,
+				}.Write()
+				_, err = conn.Write(byts)
+				require.NoError(t, err)
+
+				time.Sleep(500 * time.Millisecond)
+
+				l1, err := net.ListenPacket("udp", "localhost:34556")
+				require.NoError(t, err)
+				defer l1.Close()
+
+				l1.WriteTo(testRTPPacketMarshaled, &net.UDPAddr{
+					IP:   net.ParseIP("127.0.0.1"),
+					Port: th.ClientPorts[0],
+				})
+			}()
+
+			ru := "rtsp://localhost:8554/path1"
+			if persistCredentialsOnRedirect {
+				ru = "rtsp://testusr:testpwd@localhost:8554/path1"
+			}
+			err = c.StartReading(ru)
+			require.NoError(t, err)
+			defer c.Close()
+
+			<-packetRecv
 		})
-	}()
-
-	packetRecv := make(chan struct{})
-
-	c := Client{
-		OnPacketRTP: func(ctx *ClientOnPacketRTPCtx) {
-			close(packetRecv)
-		},
 	}
-
-	err = c.StartReading("rtsp://localhost:8554/path1")
-	require.NoError(t, err)
-	defer c.Close()
-
-	<-packetRecv
 }
 
 func TestClientReadPause(t *testing.T) {


### PR DESCRIPTION
## Background

Consider a source RTSP server that requires a set of username/password credentials. The source server is also load balancing between its' other nodes. Source server responds with a _redirected_ URL, however, due to the nature of web redirection, the credentials used to access the source server is not included in the redirection URL. When `gortsplib` is handling the redirection, it does not factor in any credentials.

## Solution
The proposed changes in this PR adds the flag `PersistCredentialsOnRedirect` to the `Client`, setting it to true results in the originally used credentials (username/password) being carried over onto the redirected URL (when the source server responds with the redirection response). This is ideal for source servers that are consistently redirecting to one of its' other servers and uses the same set of credentials for each server.

## Tests
I've modified the `TestClientReadRedirect` test case to cater for the proposed changes and built it locally, targeting linux/amd64 and used it to build the `rtsp-simple-server`. The locally built `rtsp-simple-server` binary was tested successfully with several live feeds that falls under this need.

Once this is reviewed and published, I can create the PR for the `rtsp-simple-server` that includes this flag as a part of the path config for a RTSP source.