### PR TITLE
Fix parsing of Transport header with multiple transports.

### DIFF
--- a/pkg/headers/transport.go
+++ b/pkg/headers/transport.go
@@ -75,6 +75,7 @@ type Transport struct {
 	Mode *TransportMode
 }
 
+// Transports is a list of transports.
 type Transports []Transport
 
 func parsePorts(val string) (*[2]int, error) {
@@ -105,7 +106,8 @@ func parsePorts(val string) (*[2]int, error) {
 	return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
 }
 
-func (ts *Transports) Unmarshal(v base.HeaderValue) (error) {
+// Unmarshal decodes a Transport header.
+func (ts *Transports) Unmarshal(v base.HeaderValue) error {
 	if len(v) == 0 {
 		return fmt.Errorf("value not provided")
 	}

--- a/pkg/headers/transport.go
+++ b/pkg/headers/transport.go
@@ -10,6 +10,34 @@ import (
 	"github.com/aler9/gortsplib/pkg/base"
 )
 
+func parsePorts(val string) (*[2]int, error) {
+	ports := strings.Split(val, "-")
+	if len(ports) == 2 {
+		port1, err := strconv.ParseInt(ports[0], 10, 64)
+		if err != nil {
+			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
+		}
+
+		port2, err := strconv.ParseInt(ports[1], 10, 64)
+		if err != nil {
+			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
+		}
+
+		return &[2]int{int(port1), int(port2)}, nil
+	}
+
+	if len(ports) == 1 {
+		port1, err := strconv.ParseInt(ports[0], 10, 64)
+		if err != nil {
+			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
+		}
+
+		return &[2]int{int(port1), int(port1 + 1)}, nil
+	}
+
+	return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
+}
+
 // TransportProtocol is a transport protocol.
 type TransportProtocol int
 
@@ -73,68 +101,6 @@ type Transport struct {
 
 	// (optional) mode
 	Mode *TransportMode
-}
-
-// Transports is a list of transports.
-type Transports []Transport
-
-func parsePorts(val string) (*[2]int, error) {
-	ports := strings.Split(val, "-")
-	if len(ports) == 2 {
-		port1, err := strconv.ParseInt(ports[0], 10, 64)
-		if err != nil {
-			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
-		}
-
-		port2, err := strconv.ParseInt(ports[1], 10, 64)
-		if err != nil {
-			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
-		}
-
-		return &[2]int{int(port1), int(port2)}, nil
-	}
-
-	if len(ports) == 1 {
-		port1, err := strconv.ParseInt(ports[0], 10, 64)
-		if err != nil {
-			return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
-		}
-
-		return &[2]int{int(port1), int(port1 + 1)}, nil
-	}
-
-	return &[2]int{0, 0}, fmt.Errorf("invalid ports (%v)", val)
-}
-
-// Unmarshal decodes a Transport header.
-func (ts *Transports) Unmarshal(v base.HeaderValue) error {
-	if len(v) == 0 {
-		return fmt.Errorf("value not provided")
-	}
-
-	if len(v) > 1 {
-		return fmt.Errorf("value provided multiple times (%v)", v)
-	}
-
-	*ts = nil
-
-	v0 := v[0]
-
-	transports := strings.Split(v0, ",") // , separated per RFC2326 section 12.39
-	for _, transport := range transports {
-		var tr Transport
-		err := tr.Unmarshal(base.HeaderValue{strings.TrimLeft(transport, " ")})
-		if err != nil {
-			return err
-		}
-		*ts = append(*ts, tr)
-	}
-
-	if *ts == nil {
-		return fmt.Errorf("no valid transports found")
-	}
-
-	return nil
 }
 
 // Unmarshal decodes a Transport header.
@@ -283,7 +249,7 @@ func (h *Transport) Unmarshal(v base.HeaderValue) error {
 	return nil
 }
 
-// Marshal encodes a Transport header
+// Marshal encodes a Transport header.
 func (h Transport) Marshal() base.HeaderValue {
 	var rets []string
 
@@ -351,4 +317,44 @@ func (h Transport) Marshal() base.HeaderValue {
 	}
 
 	return base.HeaderValue{strings.Join(rets, ";")}
+}
+
+// Transports is a Transport header with multiple transports.
+type Transports []Transport
+
+// Unmarshal decodes a Transport header.
+func (ts *Transports) Unmarshal(v base.HeaderValue) error {
+	if len(v) == 0 {
+		return fmt.Errorf("value not provided")
+	}
+
+	if len(v) > 1 {
+		return fmt.Errorf("value provided multiple times (%v)", v)
+	}
+
+	v0 := v[0]
+	transports := strings.Split(v0, ",") // , separated per RFC2326 section 12.39
+	*ts = make([]Transport, len(transports))
+
+	for i, transport := range transports {
+		var tr Transport
+		err := tr.Unmarshal(base.HeaderValue{strings.TrimLeft(transport, " ")})
+		if err != nil {
+			return err
+		}
+		(*ts)[i] = tr
+	}
+
+	return nil
+}
+
+// Marshal encodes a Transport header.
+func (ts Transports) Marshal() base.HeaderValue {
+	vals := make([]string, len(ts))
+
+	for i, th := range ts {
+		vals[i] = th.Marshal()[0]
+	}
+
+	return base.HeaderValue{strings.Join(vals, ",")}
 }

--- a/pkg/headers/transport_test.go
+++ b/pkg/headers/transport_test.go
@@ -1,6 +1,7 @@
 package headers
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -245,6 +246,16 @@ func TestTransportUnmarshal(t *testing.T) {
 			require.Equal(t, ca.h, h)
 		})
 	}
+}
+
+func TestTransportsUnmarshal(t *testing.T) {
+	var trs Transports
+	casea := casesTransport[0]
+	caseb := casesTransport[3]
+	h := fmt.Sprintf("%s, %s", casea.vin[0], caseb.vin[0])
+	err := trs.Unmarshal(base.HeaderValue{h})
+	require.NoError(t, err)
+	require.Equal(t, trs, Transports{casea.h, caseb.h})
 }
 
 func TestTransportUnmarshalErrors(t *testing.T) {

--- a/serversession.go
+++ b/serversession.go
@@ -604,10 +604,10 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 		// Filter out the ones we don't support and then pick first supported transport.
 		var supportedTransports headers.Transports
 		for _, tr := range inTSH {
-			isUdp := tr.Protocol == headers.TransportProtocolUDP
 			isMulticast := tr.Delivery != nil && *tr.Delivery == headers.TransportDeliveryMulticast
-			if isUdp && ((!isMulticast && ss.s.udpRTPListener == nil) ||
-				(isMulticast && ss.s.MulticastIPRange == "")) {
+			if tr.Protocol == headers.TransportProtocolUDP &&
+				((!isMulticast && ss.s.udpRTPListener == nil) ||
+					(isMulticast && ss.s.MulticastIPRange == "")) {
 				continue
 			}
 			supportedTransports = append(supportedTransports, tr)

--- a/serversession.go
+++ b/serversession.go
@@ -592,13 +592,14 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 			}, err
 		}
 
-		var inTH headers.Transport
-		err = inTH.Unmarshal(req.Header["Transport"])
+		var inTSH headers.Transports
+		err = inTSH.Unmarshal(req.Header["Transport"])
 		if err != nil {
 			return &base.Response{
 				StatusCode: base.StatusBadRequest,
 			}, liberrors.ErrServerTransportHeaderInvalid{Err: err}
 		}
+		inTH := inTSH[0]
 
 		trackID, path, query, err := setupGetTrackIDPathQuery(req.URL, inTH.Mode,
 			ss.announcedTracks, ss.setuppedPath, ss.setuppedQuery, ss.setuppedBaseURL)

--- a/serversession.go
+++ b/serversession.go
@@ -88,27 +88,19 @@ func setupGetTrackIDPathQuery(
 	return 0, "", "", fmt.Errorf("invalid track path (%s)", pathAndQuery)
 }
 
-func setupGetTransport(th headers.Transport) (Transport, bool) {
-	delivery := func() headers.TransportDelivery {
-		if th.Delivery != nil {
-			return *th.Delivery
+func findFirstSupportedTransportHeader(s *Server, tsh headers.Transports) *headers.Transport {
+	// Per RFC2326 section 12.39, client specifies transports in order of preference.
+	// Filter out the ones we don't support and then pick first supported transport.
+	for _, tr := range tsh {
+		isMulticast := tr.Delivery != nil && *tr.Delivery == headers.TransportDeliveryMulticast
+		if tr.Protocol == headers.TransportProtocolUDP &&
+			((!isMulticast && s.udpRTPListener == nil) ||
+				(isMulticast && s.MulticastIPRange == "")) {
+			continue
 		}
-		return headers.TransportDeliveryUnicast
-	}()
-
-	switch th.Protocol {
-	case headers.TransportProtocolUDP:
-		if delivery == headers.TransportDeliveryUnicast {
-			return TransportUDP, true
-		}
-		return TransportUDPMulticast, true
-
-	default: // TCP
-		if delivery != headers.TransportDeliveryUnicast {
-			return 0, false
-		}
-		return TransportTCP, true
+		return &tr
 	}
+	return nil
 }
 
 // ServerSessionState is a state of a ServerSession.
@@ -600,24 +592,12 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 			}, liberrors.ErrServerTransportHeaderInvalid{Err: err}
 		}
 
-		// Per RFC2326 section 12.39, client specifies transports in order of preference.
-		// Filter out the ones we don't support and then pick first supported transport.
-		var supportedTransports headers.Transports
-		for _, tr := range inTSH {
-			isMulticast := tr.Delivery != nil && *tr.Delivery == headers.TransportDeliveryMulticast
-			if tr.Protocol == headers.TransportProtocolUDP &&
-				((!isMulticast && ss.s.udpRTPListener == nil) ||
-					(isMulticast && ss.s.MulticastIPRange == "")) {
-				continue
-			}
-			supportedTransports = append(supportedTransports, tr)
-		}
-		if supportedTransports == nil {
+		inTH := findFirstSupportedTransportHeader(ss.s, inTSH)
+		if inTH == nil {
 			return &base.Response{
 				StatusCode: base.StatusUnsupportedTransport,
 			}, nil
 		}
-		inTH := supportedTransports[0]
 
 		trackID, path, query, err := setupGetTrackIDPathQuery(req.URL, inTH.Mode,
 			ss.announcedTracks, ss.setuppedPath, ss.setuppedQuery, ss.setuppedBaseURL)
@@ -633,35 +613,21 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 			}, liberrors.ErrServerTrackAlreadySetup{TrackID: trackID}
 		}
 
-		transport, ok := setupGetTransport(inTH)
-		if !ok {
-			return &base.Response{
-				StatusCode: base.StatusUnsupportedTransport,
-			}, nil
-		}
+		var transport Transport
 
-		switch transport {
-		case TransportUDP:
-			if inTH.ClientPorts == nil {
-				return &base.Response{
-					StatusCode: base.StatusBadRequest,
-				}, liberrors.ErrServerTransportHeaderNoClientPorts{}
+		if inTH.Protocol == headers.TransportProtocolUDP {
+			if inTH.Delivery != nil && *inTH.Delivery == headers.TransportDeliveryMulticast {
+				transport = TransportUDPMulticast
+			} else {
+				if inTH.ClientPorts == nil {
+					return &base.Response{
+						StatusCode: base.StatusBadRequest,
+					}, liberrors.ErrServerTransportHeaderNoClientPorts{}
+				}
+
+				transport = TransportUDP
 			}
-
-			if ss.s.udpRTPListener == nil {
-				return &base.Response{
-					StatusCode: base.StatusUnsupportedTransport,
-				}, nil
-			}
-
-		case TransportUDPMulticast:
-			if ss.s.MulticastIPRange == "" {
-				return &base.Response{
-					StatusCode: base.StatusUnsupportedTransport,
-				}, nil
-			}
-
-		default: // TCP
+		} else {
 			if inTH.InterleavedIDs == nil {
 				return &base.Response{
 					StatusCode: base.StatusBadRequest,
@@ -680,6 +646,8 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 					StatusCode: base.StatusBadRequest,
 				}, liberrors.ErrServerTransportHeaderInterleavedIDsAlreadyUsed{}
 			}
+
+			transport = TransportTCP
 		}
 
 		if ss.setuppedTransport != nil && *ss.setuppedTransport != transport {

--- a/serversession.go
+++ b/serversession.go
@@ -604,9 +604,10 @@ func (ss *ServerSession) handleRequest(sc *ServerConn, req *base.Request) (*base
 		// Filter out the ones we don't support and then pick first supported transport.
 		var supportedTransports headers.Transports
 		for _, tr := range inTSH {
-			if tr.Protocol == headers.TransportProtocolUDP && ss.s.udpRTPListener == nil ||
-				(tr.Delivery != nil && *tr.Delivery == headers.TransportDeliveryMulticast &&
-					ss.s.MulticastIPRange == "") {
+			isUdp := tr.Protocol == headers.TransportProtocolUDP
+			isMulticast := tr.Delivery != nil && *tr.Delivery == headers.TransportDeliveryMulticast
+			if isUdp && ((!isMulticast && ss.s.udpRTPListener == nil) ||
+				(isMulticast && ss.s.MulticastIPRange == "")) {
 				continue
 			}
 			supportedTransports = append(supportedTransports, tr)


### PR DESCRIPTION
Error 400 was being returned when Transport header contained multiple transports:

invalid transport header: invalid ports (45228-45229, RTP/AVP/TCP)

Header sent by client in request:
Transport: RTP/AVP;unicast;client_port=45228-45229, RTP/AVP/TCP;unicast;interleaved=0-1

Per RFC2326 section 12.39, the Transport header can contain multiple transports separated by comma.