### PR TITLE
server: add methods to get read and written bytes

### DIFF
--- a/pkg/bytecounter/bytecounter.go
+++ b/pkg/bytecounter/bytecounter.go
@@ -1,0 +1,45 @@
+// Package bytecounter contains a io.ReadWriter wrapper that allows to count read and written bytes.
+package bytecounter
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// ByteCounter is a io.ReadWriter wrapper that allows to count read and written bytes.
+type ByteCounter struct {
+	rw      io.ReadWriter
+	read    uint64
+	written uint64
+}
+
+// New allocates a ByteCounter.
+func New(rw io.ReadWriter) *ByteCounter {
+	return &ByteCounter{
+		rw: rw,
+	}
+}
+
+// Read implements io.ReadWriter.
+func (bc *ByteCounter) Read(p []byte) (int, error) {
+	n, err := bc.rw.Read(p)
+	atomic.AddUint64(&bc.read, uint64(n))
+	return n, err
+}
+
+// Write implements io.ReadWriter.
+func (bc *ByteCounter) Write(p []byte) (int, error) {
+	n, err := bc.rw.Write(p)
+	atomic.AddUint64(&bc.written, uint64(n))
+	return n, err
+}
+
+// ReadBytes returns the number of read bytes.
+func (bc *ByteCounter) ReadBytes() uint64 {
+	return atomic.LoadUint64(&bc.read)
+}
+
+// WrittenBytes returns the number of written bytes.
+func (bc *ByteCounter) WrittenBytes() uint64 {
+	return atomic.LoadUint64(&bc.written)
+}

--- a/pkg/bytecounter/bytecounter_test.go
+++ b/pkg/bytecounter/bytecounter_test.go
@@ -1,0 +1,20 @@
+package bytecounter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestByteCounter(t *testing.T) {
+	bc := New(bytes.NewBuffer(nil))
+
+	bc.Write([]byte{0x01, 0x02, 0x03, 0x04})
+
+	buf := make([]byte, 2)
+	bc.Read(buf)
+
+	require.Equal(t, uint64(4), bc.WrittenBytes())
+	require.Equal(t, uint64(2), bc.ReadBytes())
+}

--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -1,4 +1,4 @@
-// Package conn contains a RTSP TCP connection implementation.
+// Package conn contains a RTSP connection implementation.
 package conn
 
 import (
@@ -12,7 +12,7 @@ const (
 	readBufferSize = 4096
 )
 
-// Conn is a RTSP TCP connection.
+// Conn is a RTSP connection.
 type Conn struct {
 	w   io.Writer
 	br  *bufio.Reader

--- a/serverudpl.go
+++ b/serverudpl.go
@@ -201,7 +201,11 @@ func (u *serverUDPListener) runReader() {
 }
 
 func (u *serverUDPListener) processRTP(clientData *clientData, payload []byte) {
-	if len(payload) == (maxPacketSize + 1) {
+	plen := len(payload)
+
+	atomic.AddUint64(&clientData.session.readBytes, uint64(plen))
+
+	if plen == (maxPacketSize + 1) {
 		onDecodeError(clientData.session, fmt.Errorf("RTP packet is too big to be read with UDP"))
 		return
 	}
@@ -240,7 +244,11 @@ func (u *serverUDPListener) processRTP(clientData *clientData, payload []byte) {
 }
 
 func (u *serverUDPListener) processRTCP(clientData *clientData, payload []byte) {
-	if len(payload) == (maxPacketSize + 1) {
+	plen := len(payload)
+
+	atomic.AddUint64(&clientData.session.readBytes, uint64(plen))
+
+	if plen == (maxPacketSize + 1) {
 		onDecodeError(clientData.session, fmt.Errorf("RTCP packet is too big to be read with UDP"))
 		return
 	}


### PR DESCRIPTION
ServerConn.ReadBytes()
ServerConn.WrittenBytes()
ServerSession.ReadBytes()
ServerSession.WrittenBytes()

first step in order to implement https://github.com/aler9/rtsp-simple-server/issues/734