### PR TITLE
Improved support for he_aac

### DIFF
--- a/pkg/mpeg4audio/config.go
+++ b/pkg/mpeg4audio/config.go
@@ -108,6 +108,10 @@ func (c *Config) Unmarshal(buf []byte) error {
 			return err
 		}
 		c.Type = ObjectType(tmp)
+
+		if c.Type != ObjectTypeAACLC {
+			return fmt.Errorf("unsupported object type: %d", c.Type)
+		}
 	}
 
 	c.FrameLengthFlag, err = bits.ReadFlag(buf, &pos)

--- a/pkg/mpeg4audio/config.go
+++ b/pkg/mpeg4audio/config.go
@@ -17,8 +17,8 @@ type Config struct {
 	DependsOnCoreCoder bool
 	CoreCoderDelay     uint16
 
-	// SBR specific
-	ExtType             ObjectType
+	// SBR / PS specific
+	ExtensionType       ObjectType
 	ExtensionSampleRate int
 }
 
@@ -82,7 +82,7 @@ func (c *Config) Unmarshal(buf []byte) error {
 	}
 
 	if c.Type == ObjectTypeSBR || c.Type == ObjectTypePS {
-		c.ExtType = c.Type
+		c.ExtensionType = c.Type
 		extensionSamplingFrequencyIndex, err := bits.ReadBits(buf, &pos, 4)
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func (c Config) marshalSize() int {
 		n += 4
 	}
 
-	if c.ExtType == ObjectTypeSBR || c.ExtType == ObjectTypePS {
+	if c.ExtensionType == ObjectTypeSBR || c.ExtensionType == ObjectTypePS {
 		_, ok := reverseSampleRates[c.ExtensionSampleRate]
 		if !ok {
 			n += 28
@@ -175,8 +175,8 @@ func (c Config) Marshal() ([]byte, error) {
 	buf := make([]byte, c.marshalSize())
 	pos := 0
 
-	if c.ExtType == ObjectTypeSBR || c.ExtType == ObjectTypePS {
-		bits.WriteBits(buf, &pos, uint64(c.ExtType), 5)
+	if c.ExtensionType == ObjectTypeSBR || c.ExtensionType == ObjectTypePS {
+		bits.WriteBits(buf, &pos, uint64(c.ExtensionType), 5)
 	} else {
 		bits.WriteBits(buf, &pos, uint64(c.Type), 5)
 	}
@@ -202,7 +202,7 @@ func (c Config) Marshal() ([]byte, error) {
 	}
 	bits.WriteBits(buf, &pos, uint64(channelConfig), 4)
 
-	if c.ExtType == ObjectTypeSBR || c.ExtType == ObjectTypePS {
+	if c.ExtensionType == ObjectTypeSBR || c.ExtensionType == ObjectTypePS {
 		sampleRateIndex, ok := reverseSampleRates[c.ExtensionSampleRate]
 		if !ok {
 			bits.WriteBits(buf, &pos, uint64(0x0F), 4)

--- a/pkg/mpeg4audio/config_test.go
+++ b/pkg/mpeg4audio/config_test.go
@@ -77,13 +77,36 @@ var configCases = []struct {
 		},
 	},
 	{
-		"sbr (he-aac v1) 44.1khz stereo",
-		[]byte{0x2b, 0x8a, 0x00},
+		"sbr (he-aac v1) 44.1khz mono",
+		[]byte{0x2b, 0x8a, 0x08, 0x00},
 		Config{
-			Type:                ObjectTypeSBR,
+			Type:                ObjectTypeAACLC,
 			SampleRate:          22050,
 			ChannelCount:        1,
 			ExtensionSampleRate: 44100,
+			ExtType:             ObjectTypeSBR,
+		},
+	},
+	{
+		"sbr (he-aac v1) 44.1khz stereo",
+		[]byte{0x2b, 0x92, 0x08, 0x00}, //the data from fdk_aac
+		Config{
+			Type:                ObjectTypeAACLC,
+			SampleRate:          22050,
+			ChannelCount:        2,
+			ExtensionSampleRate: 44100,
+			ExtType:             ObjectTypeSBR,
+		},
+	},
+	{
+		"ps (he-aac v2) 48khz stereo",
+		[]byte{0xeb, 0x09, 0x88, 0x00}, //the data from fdk_aac
+		Config{
+			Type:                ObjectTypeAACLC,
+			SampleRate:          24000,
+			ChannelCount:        1, // for he_aac v2, ChannelCount only set to 1 ?
+			ExtensionSampleRate: 48000,
+			ExtType:             ObjectTypePS,
 		},
 	},
 }

--- a/pkg/mpeg4audio/config_test.go
+++ b/pkg/mpeg4audio/config_test.go
@@ -89,7 +89,7 @@ var configCases = []struct {
 	},
 	{
 		"sbr (he-aac v1) 44.1khz stereo",
-		[]byte{0x2b, 0x92, 0x08, 0x00}, //the data from fdk_aac
+		[]byte{0x2b, 0x92, 0x08, 0x00}, // the data from fdk_aac
 		Config{
 			Type:                ObjectTypeAACLC,
 			SampleRate:          22050,
@@ -100,7 +100,7 @@ var configCases = []struct {
 	},
 	{
 		"ps (he-aac v2) 48khz stereo",
-		[]byte{0xeb, 0x09, 0x88, 0x00}, //the data from fdk_aac
+		[]byte{0xeb, 0x09, 0x88, 0x00}, // the data from fdk_aac
 		Config{
 			Type:                ObjectTypeAACLC,
 			SampleRate:          24000,

--- a/pkg/mpeg4audio/config_test.go
+++ b/pkg/mpeg4audio/config_test.go
@@ -84,7 +84,7 @@ var configCases = []struct {
 			SampleRate:          22050,
 			ChannelCount:        1,
 			ExtensionSampleRate: 44100,
-			ExtType:             ObjectTypeSBR,
+			ExtensionType:       ObjectTypeSBR,
 		},
 	},
 	{
@@ -95,7 +95,7 @@ var configCases = []struct {
 			SampleRate:          22050,
 			ChannelCount:        2,
 			ExtensionSampleRate: 44100,
-			ExtType:             ObjectTypeSBR,
+			ExtensionType:       ObjectTypeSBR,
 		},
 	},
 	{
@@ -106,7 +106,7 @@ var configCases = []struct {
 			SampleRate:          24000,
 			ChannelCount:        1, // for he_aac v2, ChannelCount only set to 1 ?
 			ExtensionSampleRate: 48000,
-			ExtType:             ObjectTypePS,
+			ExtensionType:       ObjectTypePS,
 		},
 	},
 }

--- a/pkg/mpeg4audio/objecttype.go
+++ b/pkg/mpeg4audio/objecttype.go
@@ -7,4 +7,5 @@ type ObjectType int
 const (
 	ObjectTypeAACLC ObjectType = 2
 	ObjectTypeSBR   ObjectType = 5
+	ObjectTypePS    ObjectType = 29
 )


### PR DESCRIPTION
Fixed play he_aac_v1 warning via ffmpeg
```
[aac @ 0x11f73bd90] Audio object type SBR+0 is not implemented. Update your FFmpeg version to the newest one from Git. If the problem still occurs, it means that your file has a feature which has not been implemented.
```

Fixed publish he_aac_v2 error via ffmpeg
```
Could not write header for output file #0 (incorrect codec parameters ?): Server returned 400 Bad Request
Error initializing output stream 0:1 -- 
```