### PR TITLE
client: improve automatic protocol switching

### DIFF
--- a/pkg/liberrors/client.go
+++ b/pkg/liberrors/client.go
@@ -107,6 +107,22 @@ func (e ErrClientTransportHeaderInvalid) Error() string {
 	return fmt.Sprintf("invalid transport header: %v", e.Err)
 }
 
+// ErrClientServerRequestedTCP is an error that can be returned by a client.
+type ErrClientServerRequestedTCP struct{}
+
+// Error implements the error interface.
+func (e ErrClientServerRequestedTCP) Error() string {
+	return "server wants to use the TCP transport protocol"
+}
+
+// ErrClientServerRequestedUDP is an error that can be returned by a client.
+type ErrClientServerRequestedUDP struct{}
+
+// Error implements the error interface.
+func (e ErrClientServerRequestedUDP) Error() string {
+	return "server wants to use the UDP transport protocol"
+}
+
 // ErrClientTransportHeaderInvalidDelivery is an error that can be returned by a client.
 type ErrClientTransportHeaderInvalidDelivery struct{}
 


### PR DESCRIPTION
(https://github.com/aler9/rtsp-simple-server/issues/1105)

when a camera receives a UDP request and replies with a TCP response, switch protocol from UDP to TCP.